### PR TITLE
Migrate fasterxml.jackson to new version #25

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ object DependencyVersions {
     const val commonLangVersion = "3.8.1"
     const val collectionUtilsVersion = "4.3"
     const val guavaVersion = "19.0"
-    const val jacksonVersion = "2.9.9"
+    const val jacksonVersion = "2.9.9.3"
     const val mockitoVersion = "2.4.2"
     const val testNGVersion = "6.8"
     const val logbackVersion = "1.2.3"


### PR DESCRIPTION
 Самая новая версия  2.10.0.pr1 в данный момент не работает, выдает ошибки с маппингом.